### PR TITLE
Add support for Reactions, Dedupe Comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ You can use the short-codes for any GitHub emoji - make 💃 (dancer) positive a
 
 ## Displaying Reaction Counts
 
-Coming eventually. Maybe you could submit a PR? That'd be cool of you!
+Should work automatically. Reactions will also count towards your postive and negative totals if using that feature. If you want to disable the reaction feature, simply add reactions: false to your config json
 
 # Building
 

--- a/src/js/components/PullRequest.jsx
+++ b/src/js/components/PullRequest.jsx
@@ -28,7 +28,11 @@ export default class PullRequest extends React.Component {
               {pr.base.repo.full_name}
             </a>
             <span className="pull-request-number">#{pr.number}</span>
-            <Comments comments={pr.comments} computedComments={pr.computedComments} />
+            <Comments
+              comments={pr.comments}
+              computedComments={pr.computedComments}
+              computedReactions={pr.computedReactions}
+            />
           </div>
           <div className="pull-request-created" title={this.formatTime('Created', pr.created_at)}>
             Created {this.formatRelativeTime(pr.created_at)}


### PR DESCRIPTION
# Reactions!
Reactions are now supported, and appear just like the emoji they are:
![image](https://cloud.githubusercontent.com/assets/4007825/18965312/b1c21130-864a-11e6-9dfd-b75541a583c6.png)

Reactions also count towards positive and negative counts for the thumbs.

# Comment Dedupe
Say someone comments with a thumbs up, then reacts with a thumbs up, and maybe a party hat too. And your config says all of these things count as "positive comments" We will now only count that once per user. So if a user leaves 500 positive comments, counts once. But if one user leaves a party hat, and a second user leaves a thumbs up, that will count as two.

The goal here is to make each user a unique vote.