### PR TITLE
Add status indication

### DIFF
--- a/src/css/main.scss
+++ b/src/css/main.scss
@@ -118,7 +118,18 @@ footer {
 
   .pr-status {
     display: inline-block;
-    margin-right: 1rem;
+    margin-right: 1rem;    // Maintain spacing with the comments to the right
+    margin-left: -0.75rem; // Nudge this closer to the PR number
+
+    .success {
+      color: $status-success;
+    }
+    .pending {
+      color: $status-pending;
+    }
+    .failure {
+      color: $status-failure;
+    }
   }
 
   .pr-comments {
@@ -209,19 +220,5 @@ button {
     margin-right: 0.5rem;
     display: flex;
     align-items: center;
-  }
-}
-
-.pr-status {
-  margin-left: -0.75rem;
-
-  .success {
-    color: $status-success;
-  }
-  .pending {
-    color: $status-pending;
-  }
-  .failure {
-    color: $status-failure;
   }
 }

--- a/src/css/main.scss
+++ b/src/css/main.scss
@@ -1,10 +1,8 @@
 $link-color: #02779E;
 $badge-color: #354250;
 $error-color: #C34444;
-
-$status-failure: #E63434;
-$status-pending: #F0C44F;
-$status-success: #4AD964;
+$warning-color: #DFBA57;
+$success-color: #4AD964;
 
 body {
   background-color: #EEEEEE;
@@ -122,13 +120,13 @@ footer {
     margin-left: -0.75rem; // Nudge this closer to the PR number
 
     .success {
-      color: $status-success;
+      color: $success-color;
     }
     .pending {
-      color: $status-pending;
+      color: $warning-color;
     }
     .failure {
-      color: $status-failure;
+      color: $error-color;
     }
   }
 

--- a/src/css/main.scss
+++ b/src/css/main.scss
@@ -2,6 +2,10 @@ $link-color: #02779E;
 $badge-color: #354250;
 $error-color: #C34444;
 
+$status-failure: #E63434;
+$status-pending: #F0C44F;
+$status-success: #4AD964;
+
 body {
   background-color: #EEEEEE;
   font-family: 'Open Sans', sans-serif;
@@ -112,6 +116,11 @@ footer {
     color: #FFFFFF;
   }
 
+  .pr-status {
+    display: inline-block;
+    margin-right: 1rem;
+  }
+
   .pr-comments {
     display: inline-block;
 
@@ -200,5 +209,19 @@ button {
     margin-right: 0.5rem;
     display: flex;
     align-items: center;
+  }
+}
+
+.pr-status {
+  margin-left: -0.75rem;
+
+  .success {
+    color: $status-success;
+  }
+  .pending {
+    color: $status-pending;
+  }
+  .failure {
+    color: $status-failure;
   }
 }

--- a/src/js/components/PullRequest.jsx
+++ b/src/js/components/PullRequest.jsx
@@ -4,6 +4,7 @@ import moment from 'moment';
 import config from '../../config/config.json';
 import UserPhoto from './UserPhoto';
 import { hasMergeRules, isMergeable, Comments } from './Comments';
+import { Status } from './Status';
 
 const baseClassName = 'pull-request';
 const unmergeable = `${baseClassName} ${baseClassName}--unmergeable`;
@@ -50,6 +51,9 @@ export default class PullRequest extends React.Component {
               {pr.base.repo.full_name}
             </a>
             <span className="pull-request-number">#{pr.number}</span>
+            <Status
+              status={pr.status}
+            />
             <Comments
               comments={pr.comments}
               computedComments={pr.computedComments}

--- a/src/js/components/Status.jsx
+++ b/src/js/components/Status.jsx
@@ -1,0 +1,31 @@
+import React from 'react';
+
+const ICONS = {
+  success: 'check-circle',
+  pending: 'question-circle',
+  failure: 'times-circle',
+};
+
+export function Status(props) {
+  const status = props.status || {};
+
+  const { state, statuses, total_count: count } = status;
+
+  if (typeof count === 'undefined' || count === 0) {
+    return null;
+  }
+
+  const passing = statuses.filter((s) =>
+    s.state === 'success'
+  );
+
+  return (
+    <div className="pr-status" title={`Status: ${state} (${passing.length}/${count} passing)`}>
+      <i className={`fa fa-${ICONS[state]} ${state}`}></i>
+    </div>
+  );
+}
+
+Status.propTypes = {
+  status: React.PropTypes.object,
+};


### PR DESCRIPTION
For branches with [PR status checks](https://help.github.com/articles/about-required-status-checks/) (eg, CI testing), this adds indicators to show whether they're passing/failing/pending. The tooltip will say something like `Status: pending (2/3 passing)`

I'm not much of a front-end dev, so totally open to a better way to show the status.

![image](https://cloud.githubusercontent.com/assets/166175/21754633/4af1f57e-d5d2-11e6-9167-2036ca2424d2.png)
