### PR TITLE
add default title, catch statement to dismiss loading overlay

### DIFF
--- a/src/js/actions/index.js
+++ b/src/js/actions/index.js
@@ -69,7 +69,9 @@ export function loadPullRequests() {
     return axios.get('/pulls').then(response => {
       dispatch(addPullRequests(response.data.pullRequests, sortOptions));
       dispatch(setRepos(response.data.repos));
-      dispatch(setTitle(response.data.title));
+      dispatch(setTitle(response.data.title || 'Pull Requests'));
+    }).catch(() => {
+      dispatch(setError('Failed to load pull requests. Double check that all your repos exist!'));
     });
   };
 }


### PR DESCRIPTION
* Add a default title, in case you left it out of `config.json`
* Add a catch to `loadPullRequests()` and show an error message. It was possible to get a permanent loading indicator if you deleted a repo from GitHub but kept it in the config. The only way to fix it in the UI was to manually delete the overlay element to access the settings!

I'm fine making the error message more generic, since other scenarios might cause it (GitHub being down, etc). Also I still don't speak React/Redux, so if there's a better way to do this let me know!