### PR TITLE
Add abitily to tunnel HTTP over HTTP proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,11 @@ or `npm run build`.
 
 # Configuration
 
-Copy the file `config/config.json.sample` to `config/config.json`. If you are accessing public GitHub, you don't need to change the `apiBaseUrl` option. If you are accessing a GitHub Enterprise instance, you will need to set `apiBaseUrl` to the base URL of your GitHub Enterprise installation, e.g. `https://github.mycompany.com/api/v3`.  To use the GitHub Personal Access Token for accessing private repositories, `username` and `password` lines in `config/config.json` can be replaced with a single `"token": "MY_PERSONAL_TOKEN"` line. 
+Copy the file `config/config.json.sample` to `config/config.json`. If you are accessing public GitHub, you don't need to change the `apiBaseUrl` option. If you are accessing a GitHub Enterprise instance, you will need to set `apiBaseUrl` to the base URL of your GitHub Enterprise installation, e.g. `https://github.mycompany.com/api/v3`.  To use the GitHub Personal Access Token for accessing private repositories, `username` and `password` lines in `config/config.json` can be replaced with a single `"token": "MY_PERSONAL_TOKEN"` line.
 
 GitHub places a very strict rate limit on unauthenticated requests. If you run into this problem, you will need to add your GitHub username and password in `config.json`.
+
+In order to allow this code to run behind corporate firewalls (in particular those which tunnel https connections over an http proxy) additional configuration is available in an optional 'sslTunnel' section in the `config.json` - See the config.json.sample for an example - Remove this section if you do not require it in your own config.
 
 # Running the server
 To run the PR dashbaord server, run `npm start`. This will start the server, listening on port 8080. You can change the port number by setting a `PORT` environment variable, e.g. `export PORT=80`.

--- a/config/config.json.sample
+++ b/config/config.json.sample
@@ -20,5 +20,9 @@
     "positive": 2,
     "negative": 0,
     "neverRegexp": "DO NOT MERGE"
+  },
+  "sslTunnel": {
+    "host": "proxy.mycorp.com",
+    "port": 8080
   }
 }

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "webpack-dev-server": "^1.14.1"
   },
   "dependencies": {
-    "axios": "^0.13.1",
+    "axios": "^v0.19.0-beta.1",
     "bluebird": "^3.4.0",
     "body-parser": "^1.17.1",
     "emojione": "^2.2.6",
@@ -58,6 +58,7 @@
     "react-redux": "^4.4.5",
     "react-router-dom": "^4.0.0",
     "redux": "^3.5.2",
-    "redux-thunk": "^2.1.0"
+    "redux-thunk": "^2.1.0",
+    "tunnel": "0.0.6"
   }
 }

--- a/server/githubService.js
+++ b/server/githubService.js
@@ -1,8 +1,11 @@
 const axios = require('axios');
+const tunnel = require('tunnel');
 
 const configManager = require('./configManager');
 const emoji = require('./emoji');
 const reviews = require('./reviews');
+
+
 
 function apiCall(url, headers = {}) {
   const config = configManager.getConfig();
@@ -14,10 +17,19 @@ function apiCall(url, headers = {}) {
     }
   } else if (config.token ) {
     options.auth = {
-      username: config.token 
+      username: config.token
     }
   };
-  
+
+  if (config.sslTunnel) {
+     options.httpsAgent = tunnel.httpsOverHttp({
+       proxy: {
+         host: config.sslTunnel.host,
+         port: config.sslTunnel.port
+       },
+     });
+     options.proxy = false;
+  };
   return axios.get(url, options);
 }
 


### PR DESCRIPTION
The proxy support built into the axios library was not able to handle configurations where HTTPS traffic is passed through an HTTP proxy server.
This commit adds support for using the 'tunnel' library to support HTTPS-over-HTTP proxy configurations.

- Update config.sample.json with an example HTTPS proxy tunnel configuration.
- Update README.md to document added settings.
- Update githubservice.js to optionally support proxy tunnel.
- Use beta version of axios as this is required for tunnel.
