### PR TITLE
Feature: Add all organization repositories when omitting repo name

### DIFF
--- a/server/githubService.js
+++ b/server/githubService.js
@@ -119,6 +119,11 @@ exports.getRepo = function getRepo(owner, name) {
   return apiCall(`${config.apiBaseUrl}/repos/${owner}/${name}`);
 };
 
+exports.listOrganizationRepos = function listRepos(owner) {
+  const config = configManager.getConfig();
+  return apiCall(`${config.apiBaseUrl}/orgs/${owner}/repos`).then(response => response.data);
+};
+
 exports.loadPullRequests = function loadPullRequests() {
   const config = configManager.getConfig();
   const repos = config.repos;

--- a/server/index.js
+++ b/server/index.js
@@ -17,6 +17,7 @@ emoji.init();
 app.get('/pulls', requestHandlers.getPullRequests);
 app.get('/config', requestHandlers.getConfig);
 app.get('/repoExists', requestHandlers.repoExists);
+app.get('/scanOrgRepos', requestHandlers.scanOrgRepos);
 app.put('/config', requestHandlers.updateConfig);
 app.get('*', (req, res) => {
   res.sendFile(path.resolve('dist', 'index.html'));

--- a/server/requestHandlers.js
+++ b/server/requestHandlers.js
@@ -35,3 +35,15 @@ exports.repoExists = function getConfig(req, res) {
     res.status(404).json(false);
   });
 };
+
+exports.scanOrgRepos = function scanOrgRepos(req, res) {
+  githubService.listOrganizationRepos(req.query.owner).then(repos => {
+    res.status(200).json(repos.map(repo => ({ id: repo.id, name: repo.name })));
+  }).catch(error => {
+    console.error(`Error loading organization repos: ${error.message}`);
+    console.error(error);
+    res.status(500).json({
+      error: `Failed to load organization repos: ${error.message}`
+    });
+  });
+};


### PR DESCRIPTION
I added a feature to scan all organization repositories to add them at once.
On the config screen, type in the organization name and just click "add" without providing repo name.